### PR TITLE
[NOJIRA] Bump Bitrise Build Cache CLI to v3.4.4

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -65,9 +65,17 @@ workflows:
               mv bazelisk-darwin-arm64 bazel
             fi
 
-            asdf plugin add python
-            asdf install python 3.12.8
-            asdf global python 3.12.8
+            # Building a pinned CPython from source segfaults in ensurepip on
+            # macOS 26, so prefer a version the stack already has installed.
+            asdf plugin add python || true
+            PY_VERSION="$(asdf list python 2>/dev/null | tr -d ' *' | grep -E '^3\.' | tail -1)"
+            if [ -z "$PY_VERSION" ]; then
+              PY_VERSION="$(asdf latest python)"
+              asdf install python "$PY_VERSION"
+            fi
+            asdf global python "$PY_VERSION" || asdf set -u python "$PY_VERSION"
+            python3 --version
+            envman add --key ASDF_PYTHON_VERSION --value "$PY_VERSION"
 
             # Make the binary executable
             chmod +x bazel
@@ -88,7 +96,7 @@ workflows:
               
             set -ex
 
-            bazel build --action_env=ASDF_PYTHON_VERSION=3.12.8  --sandbox_debug --announce_rc --verbose_failures  //src:bazel-dev
+            bazel build --action_env=ASDF_PYTHON_VERSION="$ASDF_PYTHON_VERSION" --sandbox_debug --announce_rc --verbose_failures //src:bazel-dev
   _setup:
     envs:
     - USE_BAZEL_VERSION: 8.2.1

--- a/step.sh
+++ b/step.sh
@@ -30,7 +30,7 @@ echo "Bitrise Build Cache is activated in this workspace, configuring the build 
 set -x
 
 # download the Bitrise Build Cache CLI
-export BITRISE_BUILD_CACHE_CLI_VERSION="v0.17.7"
+export BITRISE_BUILD_CACHE_CLI_VERSION="v3.4.4"
 curl --retry 5 -m 30 -sSfL 'https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh' | sh -s -- -b /tmp/bin -d $BITRISE_BUILD_CACHE_CLI_VERSION || true
 
 # Fall back to Artifact Registry if the download failed


### PR DESCRIPTION
## TLDR

- Bumps the pinned CLI from `v0.17.7` to `v3.4.4`.
- Delivers the Bazel credential-helper fix from ACI-5269 to this step.

## Why the pin was three majors behind

This step installs the CLI by pinned version and is not part of the CLI release workflow's auto-bump set (that covers the gradle, xcode, gradle-features, RN-features and gradle-mirrors steps), so nothing pushed a bump here — the pin has been on `v0.17.7` since the Artifact Registry change in July 2025. Every CLI fix since then, including the credential-helper login loss under concurrent helper processes, has been invisible to Bazel users of this step.

The step's CLI invocation is unchanged and still valid on v3: `activate bazel --debug --cache --cache-push --rbe --timestamps` — all four subcommand flags still exist, and `--debug` remains a global flag cobra accepts after the subcommand.

## Testing

- Verified flag-for-flag compatibility against the v3.4.4 binary's `activate bazel --help`.
- e2e in this repo exercises the real install + activate path against the published v3.4.4 release.